### PR TITLE
Add a component for a write-only update endpoint

### DIFF
--- a/src/grafter/db/triplestore.clj
+++ b/src/grafter/db/triplestore.clj
@@ -36,6 +36,14 @@
     (add-data! update-endpoint load-files)
     triplestore))
 
+;; Update only endpoint
+(defmethod ig/init-key :grafter.db/update-endpoint [_ {:keys [update-endpoint]}]
+  (repo/sparql-repo nil update-endpoint))
+
+(defmethod ig/halt-key! :grafter.db/update-endpoint [_ repo]
+  (repo/shutdown repo))
+
+
 (s/def ::valid-fixture-config (fn [config]
                                 (if (:load-files config)
                                   (:update-endpoint config)

--- a/test/grafter/db/test_triplestore.clj
+++ b/test/grafter/db/test_triplestore.clj
@@ -24,7 +24,7 @@
 
 (defmethod ig/init-key :grafter.db/test-triplestore
   [_ {:keys [query-cache query-endpoint load-files update-endpoint] :as _opts}]
-  (let [repo (repo/sparql-repo query-endpoint)
+  (let [repo (repo/sparql-repo query-endpoint update-endpoint)
         triplestore (triplestore/init query-cache repo)]
     (if update-endpoint
       (add-data! triplestore update-endpoint load-files)

--- a/test/grafter/db/triplestore/query_test.clj
+++ b/test/grafter/db/triplestore/query_test.clj
@@ -4,7 +4,9 @@
             [grafter.db.triplestore.query :as q]
             [grafter-2.rdf4j.sparql :as sp]
             [grafter.vocabularies.qb :refer :all]
-            [grafter.vocabularies.rdf :refer :all])
+            [grafter.vocabularies.rdf :refer :all]
+            [grafter-2.rdf4j.repository :as repo]
+            [grafter-2.rdf.protocols :as pr])
   (:import (java.net URI)
            (grafter_2.rdf.protocols Quad)))
 
@@ -118,10 +120,10 @@
         (is (= (-> result first :obs)
                obs-uri1))))))
 
+
+
 (comment
   (require '[grafter-2.rdf4j.repository :as repo])
   (require '[grafter.db.triplestore.impl :as triplestore])
   (def repo (repo/sparql-repo "http://localhost:5820/grafter-db-dev/query"))
   (def t-store (triplestore/->TripleStoreBoundary nil repo :eager)))
-
-

--- a/test/grafter/db/triplestore_test.clj
+++ b/test/grafter/db/triplestore_test.clj
@@ -1,0 +1,32 @@
+(ns grafter.db.triplestore-test
+  (:require [grafter.db.triplestore :as sut]
+            [clojure.test :as t]
+            [grafter.db.test-helpers :as th]
+            [grafter.db.triplestore.query :as q]
+            [grafter-2.rdf4j.repository :as repo]
+            [grafter-2.rdf.protocols :as pr])
+  (:import (java.net URI)))
+
+
+(t/use-fixtures :once (th/wrap-test-system [:duct.profile/test]))
+
+
+(def test-triple (pr/->Triple (URI. "http://a") (URI. "http://a") (URI. "http://a")))
+
+(q/defquery select-s-p-o
+  "sparql/select-s-p-o.sparql"
+  [:s])
+
+(t/deftest writing-to-repo
+  (let [update-endpoint (:grafter.db/update-endpoint th/*test-system*)
+        query-endpoint (:grafter.db/test-triplestore th/*test-system*)]
+
+    (try
+      (with-open [conn (repo/->connection update-endpoint)]
+        (pr/add conn [test-triple]))
+
+      (t/is (= [{:p (URI. "http://a") :o (URI. "http://a")}]
+               (select-s-p-o query-endpoint {:s (URI. "http://a")})))
+
+      (finally
+        (pr/update! (repo/->connection update-endpoint) "DROP ALL")))))

--- a/test/test-config.edn
+++ b/test/test-config.edn
@@ -6,6 +6,9 @@
                                                            :or "http://localhost:5820/grafter-db-dev/query"]
                                 :update-endpoint #duct/env ["TEST_SPARQL_UPDATE_ENDPOINT"
                                                             :or "http://localhost:5820/grafter-db-dev/update"]}
+
+  :grafter.db/update-endpoint {:update-endpoint #duct/env ["TEST_SPARQL_UPDATE_ENDPOINT"
+                                                           :or "http://localhost:5820/grafter-db-dev/update"]}
   }
 
  :duct.profile/dev {}


### PR DESCRIPTION
I'd written this and then seen you have one too in your flood risk app @scottlowe https://github.com/Swirrl/defra-flood-risk-explorer/blob/master/app/src/defra/fre/admin/core.clj

So if we merge and deploy this you can probably delete that code at some point.